### PR TITLE
Fix linker error: multiple definition of readbuf

### DIFF
--- a/ch341eeprom.h
+++ b/ch341eeprom.h
@@ -364,6 +364,10 @@ const static struct EEPROM eepromlist[] = {
 };
 
 
+// Global variables
+extern uint8_t *readbuf;
+
+// Function prototypes
 int32_t ch341readEEPROM(struct libusb_device_handle *devHandle, uint8_t *buf, uint32_t bytes, struct EEPROM* eeprom_info);
 int32_t ch341writeEEPROM(struct libusb_device_handle *devHandle, uint8_t *buf, uint32_t bytes, struct EEPROM* eeprom_info);
 struct libusb_device_handle *ch341configure(uint16_t vid, uint16_t pid);

--- a/ch341funcs.c
+++ b/ch341funcs.c
@@ -31,7 +31,6 @@ extern FILE *debugout, *verbout;
 uint32_t getnextpkt;                            // set by the callback function
 uint32_t syncackpkt;                            // synch / ack flag used by BULK OUT cb function
 uint32_t byteoffset;
-uint8_t *readbuf;
 
 // --------------------------------------------------------------------------
 // ch341configure()


### PR DESCRIPTION
## Problem
Fixes a linker error that occurs when building with modern compilers:
```
/usr/bin/ld: multiple definition of `readbuf'
```

## Changes
- **ch341funcs.c**: Remove duplicate definition of `readbuf`
- **ch341eeprom.h**: Add proper `extern` declaration for `readbuf`

## Root Cause  
The `readbuf` variable was defined in both `ch341eeprom.c` and `ch341funcs.c`, causing a multiple definition linker error. This fix ensures there's only one definition while maintaining proper access from other source files.

## Testing
✅ Builds successfully with clang
✅ No linker errors
✅ All functionality preserved

This resolves build issues on modern Linux distributions and compilers.